### PR TITLE
Support chat tab reordering with `Shift` + drag

### DIFF
--- a/crates/steel_core/src/settings/chat.rs
+++ b/crates/steel_core/src/settings/chat.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Chat {
@@ -7,7 +6,7 @@ pub struct Chat {
     pub autoconnect: bool,
     #[serde(default)]
     pub reconnect: bool,
-    pub autojoin: BTreeSet<String>,
+    pub autojoin: Vec<String>,
     pub irc: IRCChatSettings,
     pub api: HTTPChatSettings,
 }
@@ -18,7 +17,7 @@ impl Default for Chat {
             backend: ChatBackend::default(),
             autoconnect: false,
             reconnect: true,
-            autojoin: BTreeSet::default(),
+            autojoin: Vec::default(),
             irc: IRCChatSettings::default(),
             api: HTTPChatSettings::default(),
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -165,13 +165,14 @@ impl Application {
         log::debug!("IRC connection status changed to {:?}", status);
         match status {
             ConnectionStatus::Connected => {
-                let mut chats = self.state.settings.chat.autojoin.clone();
-                chats.append(&mut self.state.chats.iter().cloned().collect());
-
-                for chat in chats {
-                    self.maybe_remember_chat(&chat, false);
-                    if chat.is_channel() {
-                        self.join_channel(&chat);
+                let chats = self.state.settings.chat.autojoin.clone();
+                let connected_to: Vec<String> = self.state.chats.iter().cloned().collect();
+                for cs in [chats, connected_to] {
+                    for chat in cs {
+                        self.maybe_remember_chat(&chat, false);
+                        if chat.is_channel() {
+                            self.join_channel(&chat);
+                        }
                     }
                 }
             }

--- a/src/gui/chat_tabs.rs
+++ b/src/gui/chat_tabs.rs
@@ -56,9 +56,19 @@ fn tab_context_menu(
     chats_to_clear: &mut BTreeSet<String>,
 ) {
     if matches!(mode, ChatType::Channel) {
-        if state.settings.chat.autojoin.contains(normalized_chat_name) {
+        if state
+            .settings
+            .chat
+            .autojoin
+            .iter()
+            .any(|s| s == normalized_chat_name)
+        {
             if ui.button("Remove from favourites").clicked() {
-                state.settings.chat.autojoin.remove(normalized_chat_name);
+                state
+                    .settings
+                    .chat
+                    .autojoin
+                    .retain(|s| s != normalized_chat_name);
                 // TODO: this should be done elsewhere, in a centralized manner, I'm just being lazy right now
                 state.core.settings_updated(&state.settings);
                 ui.close_menu();
@@ -68,7 +78,7 @@ fn tab_context_menu(
                 .settings
                 .chat
                 .autojoin
-                .insert(normalized_chat_name.to_owned());
+                .push(normalized_chat_name.to_owned());
             // TODO: this should be done elsewhere, in a centralized manner, I'm just being lazy right now
             state.core.settings_updated(&state.settings);
             ui.close_menu();

--- a/src/gui/chat_tabs.rs
+++ b/src/gui/chat_tabs.rs
@@ -13,6 +13,7 @@ pub struct ChatTabs {
     pub new_channel_input: String,
     pub new_chat_input: String,
     chat_row_height: Option<f32>,
+    tab_centers: Vec<(usize, f32)>,
 }
 
 impl ChatTabs {
@@ -47,6 +48,86 @@ fn pick_tab_colour(state: &UIState, normalized_chat_name: &str) -> Colour {
     colour.clone()
 }
 
+fn tab_context_menu(
+    ui: &mut Ui,
+    state: &mut UIState,
+    normalized_chat_name: &str,
+    mode: &ChatType,
+    chats_to_clear: &mut BTreeSet<String>,
+) {
+    if matches!(mode, ChatType::Channel) {
+        if state.settings.chat.autojoin.contains(normalized_chat_name) {
+            if ui.button("Remove from favourites").clicked() {
+                state.settings.chat.autojoin.remove(normalized_chat_name);
+                // TODO: this should be done elsewhere, in a centralized manner, I'm just being lazy right now
+                state.core.settings_updated(&state.settings);
+                ui.close_menu();
+            }
+        } else if ui.button("Add to favourites").clicked() {
+            state
+                .settings
+                .chat
+                .autojoin
+                .insert(normalized_chat_name.to_owned());
+            // TODO: this should be done elsewhere, in a centralized manner, I'm just being lazy right now
+            state.core.settings_updated(&state.settings);
+            ui.close_menu();
+        }
+    }
+
+    if ui.button("Clear messages").clicked() {
+        chats_to_clear.insert(normalized_chat_name.to_owned());
+        ui.close_menu();
+    }
+
+    let close_title = match mode {
+        ChatType::Channel => "Leave",
+        ChatType::Person => "Close",
+    };
+    if ui.button(close_title).clicked() {
+        state.core.chat_tab_closed(normalized_chat_name);
+        ui.close_menu();
+    }
+}
+
+fn drag_source(
+    ui: &mut Ui,
+    id: egui::Id,
+    own_interleaved_pos: usize,
+    tab_centers: &Vec<(usize, f32)>,
+    body: impl FnOnce(&mut egui::Ui),
+) -> Option<usize> {
+    let is_being_dragged = ui.memory(|m| m.is_being_dragged(id));
+    if !is_being_dragged {
+        // TODO: Shift is used as a workaround to prevent drag events from suppressing clicks:
+        // - https://github.com/emilk/egui/issues/2471
+        // - https://github.com/emilk/egui/issues/2730
+        let response = ui.scope(body).response;
+        if ui.input(|i| i.modifiers.shift) {
+            ui.interact(response.rect, id, egui::Sense::drag());
+        }
+        None
+    } else {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::Grabbing);
+        let layer_id = egui::LayerId::new(egui::Order::Tooltip, id);
+        let response = ui.with_layer_id(layer_id, body).response;
+
+        if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
+            let delta = pointer_pos - response.rect.center();
+            ui.ctx().translate_layer(layer_id, delta);
+            if ui.input(|i| i.pointer.primary_released()) {
+                for (interleaved_pos, center) in tab_centers {
+                    if center >= &pointer_pos.y && own_interleaved_pos != *interleaved_pos {
+                        return Some(*interleaved_pos);
+                    }
+                }
+                return Some(tab_centers.len() - 1);
+            }
+        }
+        None
+    }
+}
+
 impl ChatTabs {
     fn show_new_chat_input(&mut self, state: &mut UIState, ui: &mut Ui, mode: ChatType) {
         let input: &mut String = match mode {
@@ -61,7 +142,11 @@ impl ChatTabs {
 
         ui.vertical(|ui| {
             ui.horizontal(|ui| {
-                let add_chat = ui.button("+").on_hover_text_at_pointer("<Enter> = add");
+                let add_chat = ui.button("+").on_hover_text_at_pointer(
+                    "<Enter> = add\n\
+                    <Shift> + drag = reorder\n\
+                    Middle click = close",
+                );
                 let hint = match mode {
                     ChatType::Channel => "channel",
                     ChatType::Person => "user",
@@ -105,13 +190,14 @@ impl ChatTabs {
     }
 
     fn show_chats(&mut self, state: &mut UIState, ui: &mut Ui, mode: ChatType) {
-        let it: Vec<(String, String, ChatState)> = state
-            .filter_chats(|ch| match mode {
+        let it: Vec<(usize, String, String, ChatState)> = state
+            .filter_chats(|(_, ch)| match mode {
                 ChatType::Channel => ch.name.is_channel(),
                 ChatType::Person => !ch.name.is_channel(),
             })
-            .map(|ch| {
+            .map(|(i, ch)| {
                 (
+                    i,
                     ch.name.to_lowercase(),
                     ch.name.to_owned(),
                     ch.state.to_owned(),
@@ -125,69 +211,56 @@ impl ChatTabs {
         let area_height = chat_row_height * it.len().clamp(0, 10) as f32;
 
         let mut chats_to_clear = BTreeSet::new();
+        self.tab_centers.resize(state.chat_count(), (0, 0.));
+        let tc = self.tab_centers.clone();
+
         egui::ScrollArea::vertical()
             .id_source(format!("{mode}-tabs"))
             .auto_shrink([false, true])
             .max_height(area_height)
             .show(ui, |ui| {
-                for (normalized_chat_name, chat_name, chat_state) in it {
-                    // ui.vertical(|ui| {
+                for (interleaved_pos, normalized_chat_name, chat_name, chat_state) in it {
                     ui.horizontal(|ui| {
-                        let mut label = egui::RichText::new(&chat_name);
-                        label = label.color(pick_tab_colour(state, &normalized_chat_name));
+                        let item_id = egui::Id::new(&normalized_chat_name);
+                        let drawer = |ui: &mut egui::Ui| {
+                            let mut label = egui::RichText::new(chat_name);
+                            label = label.color(pick_tab_colour(state, &normalized_chat_name));
 
-                        let chat_tab = ui.selectable_value(
-                            &mut state.active_chat_tab_name,
-                            normalized_chat_name.to_owned(),
-                            label,
-                        );
-                        if chat_tab.clicked() {
-                            state.highlights.mark_as_read(&normalized_chat_name);
-                        }
-                        if matches!(chat_state, ChatState::JoinInProgress) {
-                            ui.spinner();
-                        }
-                        if chat_tab.middle_clicked() {
-                            state.core.chat_tab_closed(&normalized_chat_name);
-                        }
+                            let chat_tab = ui.selectable_value(
+                                &mut state.active_chat_tab_name,
+                                normalized_chat_name.to_owned(),
+                                label,
+                            );
+                            self.tab_centers[interleaved_pos] =
+                                (interleaved_pos, chat_tab.rect.center().y);
 
-                        chat_tab.context_menu(|ui| {
-                            if matches!(mode, ChatType::Channel) {
-                                if state.settings.chat.autojoin.contains(&normalized_chat_name) {
-                                    if ui.button("Remove from favourites").clicked() {
-                                        state.settings.chat.autojoin.remove(&normalized_chat_name);
-                                        // TODO: this should be done elsewhere, in a centralized manner, I'm just being lazy right now
-                                        state.core.settings_updated(&state.settings);
-                                        ui.close_menu();
-                                    }
-                                } else if ui.button("Add to favourites").clicked() {
-                                    state
-                                        .settings
-                                        .chat
-                                        .autojoin
-                                        .insert(normalized_chat_name.to_owned());
-                                    // TODO: this should be done elsewhere, in a centralized manner, I'm just being lazy right now
-                                    state.core.settings_updated(&state.settings);
-                                    ui.close_menu();
-                                }
+                            if chat_tab.clicked() {
+                                state.highlights.mark_as_read(&normalized_chat_name);
                             }
-
-                            if ui.button("Clear messages").clicked() {
-                                chats_to_clear.insert(normalized_chat_name.to_owned());
-                                ui.close_menu();
+                            if matches!(chat_state, ChatState::JoinInProgress) {
+                                ui.spinner();
                             }
-
-                            let close_title = match mode {
-                                ChatType::Channel => "Leave",
-                                ChatType::Person => "Close",
-                            };
-                            if ui.button(close_title).clicked() {
+                            if chat_tab.middle_clicked() {
                                 state.core.chat_tab_closed(&normalized_chat_name);
-                                ui.close_menu();
                             }
-                        });
+
+                            chat_tab.context_menu(|ui| {
+                                tab_context_menu(
+                                    ui,
+                                    state,
+                                    &normalized_chat_name,
+                                    &mode,
+                                    &mut chats_to_clear,
+                                )
+                            });
+                        };
+
+                        if let Some(place_after) =
+                            drag_source(ui, item_id, interleaved_pos, &tc, drawer)
+                        {
+                            state.place_tab_after(interleaved_pos, place_after);
+                        }
                     });
-                    // });
                 }
             });
 

--- a/src/gui/settings/chat.rs
+++ b/src/gui/settings/chat.rs
@@ -35,7 +35,9 @@ impl AutojoinSection {
                     } else {
                         format!("#{}", self.autojoin_channel_input)
                     };
-                    settings.chat.autojoin.insert(channel_name);
+                    if !settings.chat.autojoin.contains(&channel_name) {
+                        settings.chat.autojoin.push(channel_name);
+                    }
                     self.autojoin_channel_input.clear();
                     response.request_focus();
                 }
@@ -63,9 +65,7 @@ impl AutojoinSection {
                         to_remove.insert(name.to_owned());
                     }
                 }
-                for name in to_remove.iter() {
-                    settings.chat.autojoin.remove(name);
-                }
+                settings.chat.autojoin.retain(|s| !to_remove.contains(s));
             });
         });
     }

--- a/src/gui/state/mod.rs
+++ b/src/gui/state/mod.rs
@@ -140,6 +140,18 @@ impl UIState {
         }
     }
 
+    pub fn chat_count(&self) -> usize {
+        self.chats.len()
+    }
+
+    pub fn place_tab_after(&mut self, original_tab_idx: usize, place_after_idx: usize) {
+        let ch = self.chats.remove(original_tab_idx);
+        self.chats.insert(place_after_idx, ch);
+        for (pos, ch) in self.chats.iter().enumerate() {
+            self.name_to_chat.insert(ch.name.to_lowercase(), pos);
+        }
+    }
+
     pub fn is_active_tab(&self, target: &str) -> bool {
         self.active_chat_tab_name == target
     }
@@ -250,11 +262,11 @@ impl UIState {
     pub fn filter_chats<F>(
         &self,
         f: F,
-    ) -> std::iter::Filter<std::slice::Iter<'_, steel_core::chat::Chat>, F>
+    ) -> std::iter::Filter<std::iter::Enumerate<std::slice::Iter<'_, steel_core::chat::Chat>>, F>
     where
-        F: Fn(&&Chat) -> bool,
+        F: Fn(&(usize, &Chat)) -> bool,
     {
-        self.chats.iter().filter(f)
+        self.chats.iter().enumerate().filter(f)
     }
 
     pub fn has_chat(&self, target: &str) -> bool {

--- a/src/gui/state/mod.rs
+++ b/src/gui/state/mod.rs
@@ -31,7 +31,8 @@ pub enum UIMessageIn {
 pub struct UIState {
     pub connection: ConnectionStatus,
     pub settings: Settings,
-    chats: BTreeMap<String, Chat>,
+    chats: Vec<Chat>,
+    name_to_chat: BTreeMap<String, usize>,
     pub server_messages: Vec<Message>,
     pub active_chat_tab_name: String,
 
@@ -48,7 +49,8 @@ impl UIState {
         Self {
             connection: ConnectionStatus::default(),
             settings: Settings::default(),
-            chats: BTreeMap::default(),
+            chats: Vec::default(),
+            name_to_chat: BTreeMap::default(),
             server_messages: Vec::default(),
             active_chat_tab_name: String::new(),
             core: CoreClient::new(app_queue_handle),
@@ -114,7 +116,11 @@ impl UIState {
     }
 
     pub fn active_chat(&self) -> Option<&Chat> {
-        self.chats.get(&self.active_chat_tab_name)
+        if let Some(pos) = self.name_to_chat.get(&self.active_chat_tab_name) {
+            self.chats.get(*pos)
+        } else {
+            None
+        }
     }
 
     pub fn is_connected(&self) -> bool {
@@ -126,7 +132,9 @@ impl UIState {
         chat.state = state;
 
         let normalized = chat.name.to_lowercase();
-        self.chats.insert(normalized.to_owned(), chat);
+        self.name_to_chat
+            .insert(normalized.to_owned(), self.chats.len());
+        self.chats.push(chat);
         if switch_to_chat {
             self.active_chat_tab_name = normalized;
         }
@@ -138,8 +146,10 @@ impl UIState {
 
     pub fn set_chat_state(&mut self, target: &str, state: ChatState, reason: Option<&str>) {
         let normalized = target.to_lowercase();
-        if let Some(ch) = self.chats.get_mut(&normalized) {
-            ch.set_state(state, reason);
+        if let Some(pos) = self.name_to_chat.get(&normalized) {
+            if let Some(ch) = self.chats.get_mut(*pos) {
+                ch.set_state(state, reason);
+            }
         }
     }
 
@@ -151,38 +161,40 @@ impl UIState {
     ) {
         let normalized = target.to_lowercase();
         let tab_inactive = !self.is_active_tab(&normalized);
-        if let Some(ch) = self.chats.get_mut(&normalized) {
-            // If the chat was open with an improper case, fix it!
-            if ch.name != target {
-                ch.name = target;
-            }
-
-            message.id = Some(ch.messages.len());
-            message.parse_for_links();
-            message.detect_highlights(self.highlights.keywords());
-
-            let highlight = message.highlight;
-            if highlight {
-                self.highlights.add(&normalized, &message);
-                if self.active_chat_tab_name != HIGHLIGHTS_TAB_NAME {
-                    self.highlights.mark_as_unread(HIGHLIGHTS_TAB_NAME);
+        if let Some(pos) = self.name_to_chat.get(&normalized) {
+            if let Some(ch) = self.chats.get_mut(*pos) {
+                // If the chat was open with an improper case, fix it!
+                if ch.name != target {
+                    ch.name = target;
                 }
-            }
-            ch.push(message);
 
-            let requires_attention = highlight || !normalized.is_channel();
-            if tab_inactive {
-                if requires_attention {
-                    self.highlights.mark_as_highlighted(&normalized);
-                } else {
-                    self.highlights.mark_as_unread(&normalized);
+                message.id = Some(ch.messages.len());
+                message.parse_for_links();
+                message.detect_highlights(self.highlights.keywords());
+
+                let highlight = message.highlight;
+                if highlight {
+                    self.highlights.add(&normalized, &message);
+                    if self.active_chat_tab_name != HIGHLIGHTS_TAB_NAME {
+                        self.highlights.mark_as_unread(HIGHLIGHTS_TAB_NAME);
+                    }
                 }
-            }
+                ch.push(message);
 
-            if !frame.info().window_info.focused && requires_attention {
-                frame.request_user_attention(eframe::egui::UserAttentionType::Critical);
-                if let Some(sound) = &self.settings.notifications.highlights.sound {
-                    self.sound_player.play(sound);
+                let requires_attention = highlight || !normalized.is_channel();
+                if tab_inactive {
+                    if requires_attention {
+                        self.highlights.mark_as_highlighted(&normalized);
+                    } else {
+                        self.highlights.mark_as_unread(&normalized);
+                    }
+                }
+
+                if !frame.info().window_info.focused && requires_attention {
+                    frame.request_user_attention(eframe::egui::UserAttentionType::Critical);
+                    if let Some(sound) = &self.settings.notifications.highlights.sound {
+                        self.sound_player.play(sound);
+                    }
                 }
             }
         }
@@ -191,11 +203,14 @@ impl UIState {
     pub fn validate_reference(&self, chat_name: &str, highlight: &Message) -> bool {
         match highlight.id {
             None => false,
-            Some(id) => match self.chats.get(chat_name) {
+            Some(id) => match self.name_to_chat.get(chat_name) {
                 None => false,
-                Some(ch) => match ch.messages.get(id) {
+                Some(pos) => match self.chats.get(*pos) {
                     None => false,
-                    Some(msg) => highlight.time == msg.time,
+                    Some(ch) => match ch.messages.get(id) {
+                        None => false,
+                        Some(msg) => highlight.time == msg.time,
+                    },
                 },
             },
         }
@@ -212,13 +227,22 @@ impl UIState {
 
     pub fn remove_chat(&mut self, target: String) {
         let normalized = target.to_lowercase();
-        self.chats.remove(&normalized);
+        if let Some(pos) = self.name_to_chat.remove(&normalized) {
+            self.chats.remove(pos);
+            for ch in &self.chats[pos..] {
+                if let Some(ch) = self.name_to_chat.get_mut(&ch.name.to_lowercase()) {
+                    *ch -= 1;
+                }
+            }
+        }
         self.highlights.drop(&normalized);
     }
 
     pub fn clear_chat(&mut self, target: &str) {
-        if let Some(chat) = self.chats.get_mut(target) {
-            chat.messages.clear();
+        if let Some(pos) = self.name_to_chat.get(target) {
+            if let Some(chat) = self.chats.get_mut(*pos) {
+                chat.messages.clear();
+            }
         }
         self.highlights.drop(target);
     }
@@ -226,25 +250,25 @@ impl UIState {
     pub fn filter_chats<F>(
         &self,
         f: F,
-    ) -> std::iter::Filter<std::collections::btree_map::Values<'_, std::string::String, Chat>, F>
+    ) -> std::iter::Filter<std::slice::Iter<'_, steel_core::chat::Chat>, F>
     where
         F: Fn(&&Chat) -> bool,
     {
-        self.chats.values().filter(f)
+        self.chats.iter().filter(f)
     }
 
     pub fn has_chat(&self, target: &str) -> bool {
-        self.chats.contains_key(&target.to_lowercase())
+        self.name_to_chat.contains_key(&target.to_lowercase())
     }
 
     pub fn push_to_all_chats(&mut self, message: Message) {
-        for chat in self.chats.values_mut() {
+        for chat in self.chats.iter_mut() {
             chat.push(message.clone());
         }
     }
 
     pub fn mark_all_as_disconnected(&mut self) {
-        for chat in self.chats.values_mut() {
+        for chat in self.chats.iter_mut() {
             chat.set_state(
                 ChatState::Left,
                 Some("You have left the chat (disconnected)"),
@@ -253,7 +277,7 @@ impl UIState {
     }
 
     pub fn mark_all_as_connected(&mut self) {
-        for chat in self.chats.values_mut() {
+        for chat in self.chats.iter_mut() {
             let (new_state, reason) = match chat.name.is_channel() {
                 // Joins are handled by the app server
                 true => (ChatState::JoinInProgress, None),

--- a/src/gui/window.rs
+++ b/src/gui/window.rs
@@ -1,4 +1,4 @@
-use chrono::{Datelike, DurationRound, Timelike};
+use chrono::{DurationRound, Timelike};
 use eframe::egui;
 use tokio::sync::mpsc::{Receiver, Sender};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+// #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
 use tokio::sync::mpsc::channel;
 


### PR DESCRIPTION
closes https://github.com/TicClick/steel/issues/32. unfortunately `Shift` is required as a workaround for a framework bug: https://github.com/emilk/egui/issues/2730
