### PR TITLE
Add chat commands menu

### DIFF
--- a/crates/steel_core/src/ipc/client.rs
+++ b/crates/steel_core/src/ipc/client.rs
@@ -51,6 +51,12 @@ impl CoreClient {
             .unwrap();
     }
 
+    pub fn chat_tab_cleared(&self, normalized_name: &str) {
+        self.server
+            .blocking_send(AppMessageIn::UIChatCleared(normalized_name.to_owned()))
+            .unwrap();
+    }
+
     pub fn chat_message_sent(&self, target: &str, text: &str) {
         self.server
             .blocking_send(AppMessageIn::UIChatMessageSent {

--- a/crates/steel_core/src/ipc/client.rs
+++ b/crates/steel_core/src/ipc/client.rs
@@ -60,6 +60,15 @@ impl CoreClient {
             .unwrap();
     }
 
+    pub fn chat_action_sent(&self, target: &str, text: &str) {
+        self.server
+            .blocking_send(AppMessageIn::UIChatActionSent {
+                target: target.to_owned(),
+                text: text.to_owned(),
+            })
+            .unwrap();
+    }
+
     pub fn connect_requested(&self) {
         self.server
             .blocking_send(AppMessageIn::UIConnectRequested)

--- a/crates/steel_core/src/ipc/server.rs
+++ b/crates/steel_core/src/ipc/server.rs
@@ -19,6 +19,7 @@ pub enum AppMessageIn {
     UIChatClosed(String),
     UIChatSwitchRequested(String, usize),
     UIChatMessageSent { target: String, text: String },
+    UIChatActionSent { target: String, text: String },
     UISettingsRequested,
     UISettingsUpdated(Settings),
 

--- a/crates/steel_core/src/ipc/server.rs
+++ b/crates/steel_core/src/ipc/server.rs
@@ -17,6 +17,7 @@ pub enum AppMessageIn {
     UIChannelJoinRequested(String),
     UIPrivateChatOpened(String),
     UIChatClosed(String),
+    UIChatCleared(String),
     UIChatSwitchRequested(String, usize),
     UIChatMessageSent { target: String, text: String },
     UIChatActionSent { target: String, text: String },

--- a/crates/steel_core/src/ipc/ui.rs
+++ b/crates/steel_core/src/ipc/ui.rs
@@ -20,5 +20,6 @@ pub enum UIMessageIn {
     ChatSwitchRequested(String, usize),
     ChannelJoined(String),
     ChatClosed(String),
+    ChatCleared(String),
     ChatModeratorAdded(String),
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -304,7 +304,9 @@ impl Application {
 
     pub fn ui_handle_clear_chat(&mut self, name: &str) {
         let normalized = name.to_lowercase();
-        self.ui_queue.blocking_send(UIMessageIn::ChatCleared(normalized));
+        self.ui_queue
+            .blocking_send(UIMessageIn::ChatCleared(normalized))
+            .unwrap();
     }
 
     pub fn send_text_message(&mut self, target: &str, text: &str) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -83,6 +83,9 @@ impl Application {
                 AppMessageIn::UIChatClosed(target) => {
                     self.ui_handle_close_chat(&target);
                 }
+                AppMessageIn::UIChatCleared(target) => {
+                    self.ui_handle_clear_chat(&target);
+                }
                 AppMessageIn::UIChatMessageSent { target, text } => {
                     self.send_text_message(&target, &text);
                 }
@@ -297,6 +300,11 @@ impl Application {
         self.ui_queue
             .blocking_send(UIMessageIn::ChatClosed(name.to_owned()))
             .unwrap();
+    }
+
+    pub fn ui_handle_clear_chat(&mut self, name: &str) {
+        let normalized = name.to_lowercase();
+        self.ui_queue.blocking_send(UIMessageIn::ChatCleared(normalized));
     }
 
     pub fn send_text_message(&mut self, target: &str, text: &str) {

--- a/src/core/irc/actor.rs
+++ b/src/core/irc/actor.rs
@@ -183,8 +183,8 @@ impl IRCActor {
                     // This fixes #49 -- either Bancho loses an extra prefix colon due to its similarity with the IRC
                     // command separator, or https://github.com/aatxe/irc around the transport level, and I can't be
                     // bothered to figure out who is at fault.
-                    if content.starts_with(":") {
-                        content.insert_str(0, " ");
+                    if content.starts_with(':') {
+                        content.insert(0, ' ');
                     }
                     sender.send_privmsg(destination, content).unwrap();
                 }

--- a/src/gui/chat.rs
+++ b/src/gui/chat.rs
@@ -46,7 +46,7 @@ impl WithInnerShadow for egui::Ui {
 }
 
 #[derive(Default)]
-pub struct ChatWindow<'chat_window> {
+pub struct ChatWindow {
     chat_input: String,
     pub response_widget_id: Option<egui::Id>,
     pub scroll_to: Option<usize>,
@@ -64,10 +64,10 @@ pub struct ChatWindow<'chat_window> {
     // Chat space width -- longer lines will wrap around the window.
     widget_width: f32,
 
-    command_helper: command::CommandHelper<'chat_window>,
+    command_helper: command::CommandHelper,
 }
 
-impl<'chat_window> ChatWindow<'chat_window> {
+impl ChatWindow {
     pub fn new() -> Self {
         Self::default()
     }

--- a/src/gui/chat.rs
+++ b/src/gui/chat.rs
@@ -8,7 +8,7 @@ use crate::core::chat::{Chat, ChatLike, Message, MessageChunk, MessageType};
 use crate::gui::state::UIState;
 use crate::gui::DecoratedText;
 
-use crate::gui::command;
+use crate::gui::command::{self, COMMAND_PREFIX};
 
 const MAX_MESSAGE_LENGTH: usize = 450;
 
@@ -76,13 +76,6 @@ impl ChatWindow {
         let interactive = state.is_connected() && state.active_chat().is_some();
         if interactive {
             egui::TopBottomPanel::bottom("input").show(ctx, |ui| {
-                self.command_helper.maybe_show(
-                    ui,
-                    state,
-                    &mut self.chat_input,
-                    &self.response_widget_id,
-                );
-
                 ui.vertical_centered_justified(|ui| {
                     let message_length_exceeded = self.chat_input.len() >= 450;
 
@@ -134,6 +127,22 @@ impl ChatWindow {
         // Source of wisdom: https://github.com/emilk/egui/blob/c86bfb6e67abf208dccd7e006ccd9c3675edcc2f/crates/egui_demo_lib/src/demo/table_demo.rs
 
         egui::CentralPanel::default().show(ctx, |ui| {
+            if self.chat_input.starts_with(COMMAND_PREFIX) {
+                egui::Window::new("chat-command-hint-layer")
+                    .title_bar(false)
+                    .resizable(false)
+                    .pivot(egui::Align2::LEFT_BOTTOM)
+                    .fixed_pos(ui.available_rect_before_wrap().left_bottom())
+                    .show(ctx, |ui| {
+                        self.command_helper.maybe_show(
+                            ui,
+                            state,
+                            &mut self.chat_input,
+                            &self.response_widget_id,
+                        );
+                    });
+            }
+
             // Default spacing, which is by default zero for table rows.
             ui.spacing_mut().item_spacing.y = 4.;
             self.widget_width = ui.available_width();

--- a/src/gui/chat.rs
+++ b/src/gui/chat.rs
@@ -76,8 +76,12 @@ impl ChatWindow {
         let interactive = state.is_connected() && state.active_chat().is_some();
         if interactive {
             egui::TopBottomPanel::bottom("input").show(ctx, |ui| {
-                self.command_helper
-                    .maybe_show(ui, state, &mut self.chat_input);
+                self.command_helper.maybe_show(
+                    ui,
+                    state,
+                    &mut self.chat_input,
+                    &self.response_widget_id,
+                );
 
                 ui.vertical_centered_justified(|ui| {
                     let message_length_exceeded = self.chat_input.len() >= 450;

--- a/src/gui/chat.rs
+++ b/src/gui/chat.rs
@@ -8,7 +8,7 @@ use crate::core::chat::{Chat, ChatLike, Message, MessageChunk, MessageType};
 use crate::gui::state::UIState;
 use crate::gui::DecoratedText;
 
-use crate::gui::command::{self, COMMAND_PREFIX};
+use crate::gui::command;
 
 const MAX_MESSAGE_LENGTH: usize = 450;
 
@@ -127,14 +127,17 @@ impl ChatWindow {
         // Source of wisdom: https://github.com/emilk/egui/blob/c86bfb6e67abf208dccd7e006ccd9c3675edcc2f/crates/egui_demo_lib/src/demo/table_demo.rs
 
         egui::CentralPanel::default().show(ctx, |ui| {
-            if self.chat_input.starts_with(COMMAND_PREFIX) {
+            if self
+                .command_helper
+                .has_applicable_commands(&self.chat_input)
+            {
                 egui::Window::new("chat-command-hint-layer")
                     .title_bar(false)
                     .resizable(false)
                     .pivot(egui::Align2::LEFT_BOTTOM)
                     .fixed_pos(ui.available_rect_before_wrap().left_bottom())
                     .show(ctx, |ui| {
-                        self.command_helper.maybe_show(
+                        self.command_helper.show(
                             ui,
                             state,
                             &mut self.chat_input,

--- a/src/gui/chat.rs
+++ b/src/gui/chat.rs
@@ -103,15 +103,15 @@ impl<'chat_window> ChatWindow<'chat_window> {
                     ui.add_space(2.);
 
                     if let Some(ch) = state.active_chat() {
-                        if response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
-                            if !self
+                        if response.lost_focus()
+                            && ui.input(|i| i.key_pressed(egui::Key::Enter))
+                            && !self
                                 .command_helper
-                                .try_run_command(state, &mut self.chat_input)
-                            {
-                                state.core.chat_message_sent(&ch.name, &self.chat_input);
-                                self.chat_input.clear();
-                                response.request_focus();
-                            }
+                                .detect_and_run(state, &mut self.chat_input)
+                        {
+                            state.core.chat_message_sent(&ch.name, &self.chat_input);
+                            self.chat_input.clear();
+                            response.request_focus();
                         }
                     }
                 });
@@ -237,6 +237,7 @@ impl<'chat_window> ChatWindow<'chat_window> {
     ) {
         let msg = &ch.messages[message_index];
 
+        #[allow(unused_mut)] // glass
         let mut username_styles = BTreeSet::<TextStyle>::new();
         let mut message_styles = BTreeSet::<TextStyle>::new();
 
@@ -352,6 +353,7 @@ impl<'chat_window> ChatWindow<'chat_window> {
         }
         .with_styles(styles, &state.settings);
 
+        #[allow(unused_mut)] // glass
         let mut resp = ui.button(username_text);
 
         #[cfg(feature = "glass")]
@@ -428,6 +430,7 @@ fn show_datetime(
     })
 }
 
+#[allow(unused_variables)] // glass
 fn show_username_menu(ui: &mut egui::Ui, state: &UIState, chat_name: &str, message: &Message) {
     if state.is_connected() && ui.button("💬 Open chat").clicked() {
         state.core.private_chat_opened(&message.username);

--- a/src/gui/command.rs
+++ b/src/gui/command.rs
@@ -203,7 +203,13 @@ impl CommandHelper {
         input.starts_with(COMMAND_PREFIX)
     }
 
-    pub fn maybe_show(&self, ui: &mut egui::Ui, state: &UIState, input: &mut String) {
+    pub fn maybe_show(
+        &self,
+        ui: &mut egui::Ui,
+        state: &UIState,
+        input: &mut String,
+        chat_input_id: &Option<egui::Id>,
+    ) {
         if !self.contains_command(input) {
             return;
         }
@@ -218,11 +224,16 @@ impl CommandHelper {
                     .on_hover_ui_at_pointer(|ui| cmd.ui_hint(ui))
                     .clicked()
             {
-                // TODO(TicClick): Move the cursor to the end of the message
-
                 if argcount == 0 {
                     // Nothing entered: complete the command
                     *input = format!("{} ", cmd.preferred_alias());
+                    if let Some(ciid) = chat_input_id {
+                        if let Some(mut state) = egui::TextEdit::load_state(ui.ctx(), *ciid) {
+                            let ccursor = egui::text::CCursor::new(input.chars().count());
+                            state.set_ccursor_range(Some(egui::text::CCursorRange::one(ccursor)));
+                            state.store(ui.ctx(), *ciid);
+                        }
+                    }
                 } else if argcount < cmd.argcount() && !input.ends_with(' ') {
                     // add extra hint
                     input.push(' ');

--- a/src/gui/command.rs
+++ b/src/gui/command.rs
@@ -90,7 +90,9 @@ impl<'command> Command<'command> for CloseChat {
         ui.label("close the active tab, or leave the channel");
     }
     fn action(&self, state: &UIState, _args: Vec<String>) {
-        state.core.chat_tab_closed(&state.active_chat_tab_name.to_lowercase());
+        state
+            .core
+            .chat_tab_closed(&state.active_chat_tab_name.to_lowercase());
     }
 }
 
@@ -109,7 +111,9 @@ impl<'command> Command<'command> for ClearChat {
         ui.label("clear the active tab, removing all messages");
     }
     fn action(&self, state: &UIState, _args: Vec<String>) {
-        state.core.chat_tab_cleared(&state.active_chat_tab_name.to_lowercase())
+        state
+            .core
+            .chat_tab_cleared(&state.active_chat_tab_name.to_lowercase())
     }
 }
 

--- a/src/gui/command.rs
+++ b/src/gui/command.rs
@@ -4,14 +4,13 @@ use super::state::UIState;
 
 pub const COMMAND_PREFIX: char = '/';
 
-pub const COMMAND_ALIAS_ME: [&str; 1] = ["/me"];
-pub const COMMAND_ALIAS_OPEN_CHAT: [&str; 4] = ["/chat", "/query", "/q", "/join"];
-pub const COMMAND_ALIAS_CLOSE_CHAT: [&str; 2] = ["/close", "/part"];
-pub const COMMAND_ALIAS_CLEAR_CHAT: [&str; 2] = ["/clear", "/c"];
+trait Command {
+    fn new() -> Self
+    where
+        Self: Sized;
 
-trait Command<'command> {
-    fn aliases(&self) -> Vec<&'command str>;
-    fn preferred_alias(&self) -> &'command str {
+    fn aliases(&self) -> &Vec<String>;
+    fn preferred_alias(&self) -> &String {
         self.aliases().first().unwrap()
     }
     fn argcount(&self) -> usize;
@@ -28,14 +27,23 @@ trait Command<'command> {
     }
 
     fn is_applicable(&self, input_prefix: &str) -> bool {
-        self.aliases().contains(&input_prefix)
+        self.aliases().iter().any(|a| a == input_prefix)
     }
 }
 
-struct Me {}
-impl<'command> Command<'command> for Me {
-    fn aliases(&self) -> Vec<&'command str> {
-        COMMAND_ALIAS_ME.to_vec()
+struct Me {
+    pub aliases: Vec<String>,
+}
+
+impl Command for Me {
+    fn new() -> Self {
+        Self {
+            aliases: ["/me".into()].to_vec(),
+        }
+    }
+
+    fn aliases(&self) -> &Vec<String> {
+        &self.aliases
     }
     fn argcount(&self) -> usize {
         1
@@ -56,10 +64,18 @@ impl<'command> Command<'command> for Me {
     }
 }
 
-struct OpenChat {}
-impl<'command> Command<'command> for OpenChat {
-    fn aliases(&self) -> Vec<&'command str> {
-        COMMAND_ALIAS_OPEN_CHAT.to_vec()
+struct OpenChat {
+    pub aliases: Vec<String>,
+}
+
+impl Command for OpenChat {
+    fn new() -> Self {
+        Self {
+            aliases: ["/chat".into(), "/query".into(), "/q".into(), "/join".into()].to_vec(),
+        }
+    }
+    fn aliases(&self) -> &Vec<String> {
+        &self.aliases
     }
     fn argcount(&self) -> usize {
         1
@@ -75,10 +91,18 @@ impl<'command> Command<'command> for OpenChat {
     }
 }
 
-struct CloseChat {}
-impl<'command> Command<'command> for CloseChat {
-    fn aliases(&self) -> Vec<&'command str> {
-        COMMAND_ALIAS_CLOSE_CHAT.to_vec()
+struct CloseChat {
+    pub aliases: Vec<String>,
+}
+
+impl Command for CloseChat {
+    fn new() -> Self {
+        Self {
+            aliases: ["/close".into(), "/part".into()].to_vec(),
+        }
+    }
+    fn aliases(&self) -> &Vec<String> {
+        &self.aliases
     }
     fn argcount(&self) -> usize {
         0
@@ -96,10 +120,18 @@ impl<'command> Command<'command> for CloseChat {
     }
 }
 
-struct ClearChat {}
-impl<'command> Command<'command> for ClearChat {
-    fn aliases(&self) -> Vec<&'command str> {
-        COMMAND_ALIAS_CLEAR_CHAT.to_vec()
+struct ClearChat {
+    pub aliases: Vec<String>,
+}
+
+impl Command for ClearChat {
+    fn new() -> Self {
+        Self {
+            aliases: ["/clear".into(), "/c".into()].to_vec(),
+        }
+    }
+    fn aliases(&self) -> &Vec<String> {
+        &self.aliases
     }
     fn argcount(&self) -> usize {
         0
@@ -117,24 +149,24 @@ impl<'command> Command<'command> for ClearChat {
     }
 }
 
-pub struct CommandHelper<'command> {
-    commands: Vec<Box<dyn Command<'command>>>,
+pub struct CommandHelper {
+    commands: Vec<Box<dyn Command>>,
 }
 
-impl Default for CommandHelper<'_> {
+impl Default for CommandHelper {
     fn default() -> Self {
         Self {
             commands: vec![
-                Box::new(Me {}),
-                Box::new(OpenChat {}),
-                Box::new(CloseChat {}),
-                Box::new(ClearChat {}),
+                Box::new(Me::new()),
+                // Box::new(OpenChat::new()),
+                // Box::new(CloseChat::new()),
+                // Box::new(ClearChat::new()),
             ],
         }
     }
 }
 
-impl CommandHelper<'_> {
+impl CommandHelper {
     pub fn contains_command(&self, input: &str) -> bool {
         input.starts_with(COMMAND_PREFIX)
     }

--- a/src/gui/command.rs
+++ b/src/gui/command.rs
@@ -18,19 +18,23 @@ trait Command {
     fn argcount(&self) -> usize;
 
     fn ui_hint(&self, ui: &mut egui::Ui) {
+        ui.spacing_mut().item_spacing = [0.0, 0.0].into();
         ui.vertical(|ui| {
             ui.horizontal(|ui| {
-                ui.label(egui::RichText::new("- description:").strong());
+                ui.label(egui::RichText::new("- description: ").strong());
                 ui.label(self.description());
             });
             ui.horizontal(|ui| {
-                ui.label(egui::RichText::new("- example:").strong());
+                ui.label(egui::RichText::new("- example: ").strong());
                 ui.label(self.example());
             });
             ui.horizontal(|ui| {
-                ui.label(egui::RichText::new("- aliases:").strong());
+                ui.label(egui::RichText::new("- aliases: ").strong());
                 ui.label(self.aliases().join(", "));
             });
+            if self.argcount() == 0 {
+                ui.label("(immediate)");
+            }
         });
     }
     fn ui_title(&self) -> egui::RichText;
@@ -180,14 +184,17 @@ pub struct CommandHelper {
 
 impl Default for CommandHelper {
     fn default() -> Self {
-        Self {
+        let mut s = Self {
             commands: vec![
                 Box::new(Me::new()),
                 Box::new(OpenChat::new()),
                 Box::new(CloseChat::new()),
                 Box::new(ClearChat::new()),
             ],
-        }
+        };
+        s.commands
+            .sort_by(|c1, c2| c1.preferred_alias().cmp(c2.preferred_alias()));
+        s
     }
 }
 

--- a/src/gui/command.rs
+++ b/src/gui/command.rs
@@ -7,6 +7,7 @@ pub const COMMAND_PREFIX: char = '/';
 pub const COMMAND_ALIAS_ME: [&str; 1] = ["/me"];
 pub const COMMAND_ALIAS_OPEN_CHAT: [&str; 4] = ["/chat", "/query", "/q", "/join"];
 pub const COMMAND_ALIAS_CLOSE_CHAT: [&str; 2] = ["/close", "/part"];
+pub const COMMAND_ALIAS_CLEAR_CHAT: [&str; 2] = ["/clear", "/c"];
 
 trait Command<'command> {
     fn aliases(&self) -> Vec<&'command str>;
@@ -93,6 +94,25 @@ impl<'command> Command<'command> for CloseChat {
     }
 }
 
+struct ClearChat {}
+impl<'command> Command<'command> for ClearChat {
+    fn aliases(&self) -> Vec<&'command str> {
+        COMMAND_ALIAS_CLEAR_CHAT.to_vec()
+    }
+    fn argcount(&self) -> usize {
+        0
+    }
+    fn rich_text_example(&self) -> egui::RichText {
+        egui::RichText::new("/clear, /c")
+    }
+    fn hint(&self, ui: &mut egui::Ui) {
+        ui.label("clear the active tab, removing all messages");
+    }
+    fn action(&self, state: &UIState, _args: Vec<String>) {
+        state.core.chat_tab_cleared(&state.active_chat_tab_name.to_lowercase())
+    }
+}
+
 pub struct CommandHelper<'command> {
     commands: Vec<Box<dyn Command<'command>>>,
 }
@@ -104,6 +124,7 @@ impl Default for CommandHelper<'_> {
                 Box::new(Me {}),
                 Box::new(OpenChat {}),
                 Box::new(CloseChat {}),
+                Box::new(ClearChat {}),
             ],
         }
     }

--- a/src/gui/command.rs
+++ b/src/gui/command.rs
@@ -32,9 +32,6 @@ trait Command {
                 ui.label(egui::RichText::new("- aliases: ").strong());
                 ui.label(self.aliases().join(", "));
             });
-            if self.argcount() == 0 {
-                ui.label("(immediate)");
-            }
         });
     }
     fn ui_title(&self) -> egui::RichText;

--- a/src/gui/command.rs
+++ b/src/gui/command.rs
@@ -200,7 +200,17 @@ impl CommandHelper {
         input.starts_with(COMMAND_PREFIX)
     }
 
-    pub fn maybe_show(
+    pub fn has_applicable_commands(&self, input: &str) -> bool {
+        self.contains_command(input) && {
+            let args: Vec<String> = input.split_whitespace().map(|i| i.to_owned()).collect();
+            let argcount = args.len() - 1;
+            self.commands
+                .iter()
+                .any(|c| c.should_be_hinted(&args[0], argcount))
+        }
+    }
+
+    pub fn show(
         &self,
         ui: &mut egui::Ui,
         state: &UIState,

--- a/src/gui/command.rs
+++ b/src/gui/command.rs
@@ -1,0 +1,123 @@
+use eframe::egui;
+
+use super::state::UIState;
+
+pub const COMMAND_PREFIX: char = '/';
+
+pub const COMMAND_ALIAS_ME: [&str; 1] = ["/me"];
+
+trait Command<'command> {
+    fn aliases(&self) -> Vec<&'command str>;
+    fn preferred_alias(&self) -> &'command str {
+        self.aliases().first().unwrap()
+    }
+    fn argcount(&self) -> usize;
+
+    fn hint(&self, ui: &mut egui::Ui);
+    fn rich_text_example(&self) -> egui::RichText;
+    fn action(&self, state: &UIState, args: Vec<String>);
+
+    fn should_be_hinted(&self, input_parts: &[String], argcount: usize) -> bool {
+        self.aliases()
+            .iter()
+            .any(|alias| alias.starts_with(&input_parts[0]) || input_parts[0].starts_with(alias))
+            && (argcount < self.argcount() || argcount == 0 && self.argcount() == 0)
+    }
+
+    fn is_applicable(&self, input_parts: &[String]) -> bool {
+        self.aliases().contains(&input_parts[0].as_str())
+    }
+}
+
+struct Me {}
+impl<'command> Command<'command> for Me {
+    fn aliases(&self) -> Vec<&'command str> {
+        COMMAND_ALIAS_ME.to_vec()
+    }
+    fn argcount(&self) -> usize {
+        1
+    }
+    fn rich_text_example(&self) -> egui::RichText {
+        egui::RichText::new("/me <action>")
+    }
+    fn hint(&self, ui: &mut egui::Ui) {
+        ui.vertical(|ui| {
+            ui.label("send a third-person action to the chat.");
+            ui.label("example: /me gets to live one more day");
+        });
+    }
+    fn action(&self, state: &UIState, args: Vec<String>) {
+        state
+            .core
+            .chat_action_sent(&state.active_chat_tab_name, args.join(" ").as_str());
+    }
+}
+
+pub struct CommandHelper<'command> {
+    commands: Vec<Box<dyn Command<'command>>>,
+}
+
+impl Default for CommandHelper<'_> {
+    fn default() -> Self {
+        Self {
+            commands: vec![Box::new(Me {})],
+        }
+    }
+}
+
+impl CommandHelper<'_> {
+    pub fn contains_command(&self, input: &str) -> bool {
+        input.starts_with(COMMAND_PREFIX)
+    }
+
+    pub fn maybe_show(&self, ui: &mut egui::Ui, state: &UIState, input: &mut String) {
+        if !self.contains_command(input) {
+            return;
+        }
+
+        let args: Vec<String> = input.split_whitespace().map(|i| i.to_owned()).collect();
+        let argcount = args.len() - 1;
+
+        for cmd in &self.commands {
+            if cmd.should_be_hinted(&args, argcount) {
+                if ui
+                    .button(cmd.rich_text_example())
+                    .on_hover_ui_at_pointer(|ui| cmd.hint(ui))
+                    .clicked()
+                {
+                    // TODO(TicClick): Move the cursor to the end of the message
+
+                    if argcount == 0 {
+                        // Nothing entered: complete the command
+                        *input = format!("{} ", cmd.preferred_alias());
+                    } else if argcount < cmd.argcount() && !input.ends_with(' ') {
+                        // add extra hint
+                        input.push(' ');
+                    }
+
+                    if cmd.argcount() == 0 {
+                        cmd.action(state, args);
+                        input.clear();
+                    }
+                    ui.close_menu();
+                    break;
+                }
+            }
+        }
+    }
+
+    pub fn try_run_command(&self, state: &UIState, input: &mut String) -> bool {
+        if !self.contains_command(input) {
+            return false;
+        }
+        let args: Vec<String> = input.split_whitespace().map(|i| i.to_owned()).collect();
+        for cmd in &self.commands {
+            if cmd.is_applicable(&args) {
+                cmd.action(state, args);
+                input.clear();
+                return true;
+            }
+        }
+        false
+    }
+}

--- a/src/gui/command.rs
+++ b/src/gui/command.rs
@@ -79,34 +79,33 @@ impl CommandHelper<'_> {
         let argcount = args.len() - 1;
 
         for cmd in &self.commands {
-            if cmd.should_be_hinted(&args, argcount) {
-                if ui
+            if cmd.should_be_hinted(&args, argcount)
+                && ui
                     .button(cmd.rich_text_example())
                     .on_hover_ui_at_pointer(|ui| cmd.hint(ui))
                     .clicked()
-                {
-                    // TODO(TicClick): Move the cursor to the end of the message
+            {
+                // TODO(TicClick): Move the cursor to the end of the message
 
-                    if argcount == 0 {
-                        // Nothing entered: complete the command
-                        *input = format!("{} ", cmd.preferred_alias());
-                    } else if argcount < cmd.argcount() && !input.ends_with(' ') {
-                        // add extra hint
-                        input.push(' ');
-                    }
-
-                    if cmd.argcount() == 0 {
-                        cmd.action(state, args);
-                        input.clear();
-                    }
-                    ui.close_menu();
-                    break;
+                if argcount == 0 {
+                    // Nothing entered: complete the command
+                    *input = format!("{} ", cmd.preferred_alias());
+                } else if argcount < cmd.argcount() && !input.ends_with(' ') {
+                    // add extra hint
+                    input.push(' ');
                 }
+
+                if cmd.argcount() == 0 {
+                    cmd.action(state, args);
+                    input.clear();
+                }
+                ui.close_menu();
+                break;
             }
         }
     }
 
-    pub fn try_run_command(&self, state: &UIState, input: &mut String) -> bool {
+    pub fn detect_and_run(&self, state: &UIState, input: &mut String) -> bool {
         if !self.contains_command(input) {
             return false;
         }

--- a/src/gui/command.rs
+++ b/src/gui/command.rs
@@ -43,7 +43,7 @@ trait Command {
     fn should_be_hinted(&self, input_prefix: &str, argcount: usize) -> bool {
         self.aliases()
             .iter()
-            .any(|alias| alias.starts_with(input_prefix) || input_prefix.starts_with(alias))
+            .any(|alias| alias.starts_with(input_prefix))
             && (argcount < self.argcount() || argcount == 0 && self.argcount() == 0)
     }
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -6,6 +6,7 @@ use steel_core::TextStyle;
 pub mod about;
 pub mod chat;
 pub mod chat_tabs;
+pub mod command;
 pub mod highlights;
 pub mod menu;
 pub mod settings;

--- a/src/gui/window.rs
+++ b/src/gui/window.rs
@@ -124,9 +124,9 @@ impl DateAnnouncer {
     }
 }
 
-pub struct ApplicationWindow<'application> {
+pub struct ApplicationWindow {
     menu: gui::menu::Menu,
-    chat: gui::chat::ChatWindow<'application>,
+    chat: gui::chat::ChatWindow,
     chat_tabs: gui::chat_tabs::ChatTabs,
     settings: gui::settings::SettingsWindow,
     about: gui::about::About,
@@ -137,7 +137,7 @@ pub struct ApplicationWindow<'application> {
     date_announcer: DateAnnouncer,
 }
 
-impl<'application> ApplicationWindow<'application> {
+impl ApplicationWindow {
     pub fn new(
         cc: &eframe::CreationContext,
         ui_queue: Receiver<UIMessageIn>,
@@ -289,7 +289,7 @@ impl<'application> ApplicationWindow<'application> {
 
 const MIN_IDLE_FRAME_TIME: std::time::Duration = std::time::Duration::from_millis(200);
 
-impl eframe::App for ApplicationWindow<'_> {
+impl eframe::App for ApplicationWindow {
     fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         ctx.request_repaint_after(MIN_IDLE_FRAME_TIME);
         self.process_pending_events(ctx);

--- a/src/gui/window.rs
+++ b/src/gui/window.rs
@@ -262,6 +262,10 @@ impl<'application> ApplicationWindow<'application> {
                     self.s.remove_chat(name);
                 }
 
+                UIMessageIn::ChatCleared(name) => {
+                    self.s.clear_chat(&name);
+                }
+
                 UIMessageIn::ChatModeratorAdded(name) => {
                     for mods in [
                         &mut self.s.settings.ui.dark_colours.mod_users,

--- a/src/gui/window.rs
+++ b/src/gui/window.rs
@@ -124,9 +124,9 @@ impl DateAnnouncer {
     }
 }
 
-pub struct ApplicationWindow {
+pub struct ApplicationWindow<'application> {
     menu: gui::menu::Menu,
-    chat: gui::chat::ChatWindow,
+    chat: gui::chat::ChatWindow<'application>,
     chat_tabs: gui::chat_tabs::ChatTabs,
     settings: gui::settings::SettingsWindow,
     about: gui::about::About,
@@ -137,7 +137,7 @@ pub struct ApplicationWindow {
     date_announcer: DateAnnouncer,
 }
 
-impl ApplicationWindow {
+impl<'application> ApplicationWindow<'application> {
     pub fn new(
         cc: &eframe::CreationContext,
         ui_queue: Receiver<UIMessageIn>,
@@ -285,7 +285,7 @@ impl ApplicationWindow {
 
 const MIN_IDLE_FRAME_TIME: std::time::Duration = std::time::Duration::from_millis(200);
 
-impl eframe::App for ApplicationWindow {
+impl eframe::App for ApplicationWindow<'_> {
     fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         ctx.request_repaint_after(MIN_IDLE_FRAME_TIME);
         self.process_pending_events(ctx);


### PR DESCRIPTION
part of https://github.com/TicClick/steel/issues/36

TODO:
- [x] better position for the hint list
- [x] sort commands ~~(no arguments A-Z, 1+ arguments A-Z)~~
- [x] better command hint on hover
  - [x] table-like structure: description, examples, aliases
  - [ ] ~~indicate that some commands are executed on click~~ I think it's obvious enough
- [x] UI: move caret to the end of the input after it's changed