### PR TITLE
Fix startup crash in `x86_64-apple-darwin` targets running on Apple silicon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "steel"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 build = "src/build.rs"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,8 @@ fn setup_logging() {
         simplelog::ConfigBuilder::new()
             .set_time_format_custom(time_format)
             .set_time_offset_to_local()
-            .unwrap()
+            // https://github.com/jhpratt/num_threads/issues/18 -- time = "0.3.34" compiled to x86_64-apple-darwin can't determine UTC offset on Apple silicon (aarch64-apple-darwin)
+            .unwrap_or_else(|e| e)
             .build(),
         file,
     )


### PR DESCRIPTION
the downside is that log timestamps will be UTC