### PR TITLE
CI: Switch to MacOS 13 (x86_64) / 14 (ARM) runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-13  # x86_64
+          - macos-14  # aarch64 (ARM)
           - windows-latest
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-13  # x86_64
+          - macos-14  # aarch64 (ARM)
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -53,7 +54,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-13  # x86_64
+          - macos-14  # aarch64 (ARM)
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
- https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
- https://github.com/actions/runner-images

part of https://github.com/TicClick/steel/issues/88