### PR TITLE
Follow the active audio device change on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,8 +914,7 @@ dependencies = [
 [[package]]
 name = "cpal"
 version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d959d90e938c5493000514b446987c07aed46c668faaa7d34d6c7a67b1a578c"
+source = "git+https://github.com/TicClick/cpal.git?branch=master#7e82d99bfaa8036cf6e7c7d214254014ad050139"
 dependencies = [
  "alsa",
  "core-foundation-sys",
@@ -2923,14 +2922,14 @@ dependencies = [
 [[package]]
 name = "rodio"
 version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1bb7b48ee48471f55da122c0044fcc7600cfcc85db88240b89cb832935e611"
+source = "git+https://github.com/TicClick/rodio.git?branch=master#f46fe68a4eedae97a6b5178ea337989e628bf9d0"
 dependencies = [
  "claxon",
  "cpal",
  "hound",
  "lewton",
  "symphonia",
+ "thiserror",
 ]
 
 [[package]]
@@ -4083,6 +4082,8 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
 dependencies = [
+ "windows-implement 0.46.0",
+ "windows-interface 0.46.0",
  "windows-targets 0.42.2",
 ]
 
@@ -4092,8 +4093,8 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.48.0",
+ "windows-interface 0.48.0",
  "windows-targets 0.48.5",
 ]
 
@@ -4108,9 +4109,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b4fb59529addad98f7677797a3449b0c79f527e1384a86f74557860d387c26"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e2ee588991b9e7e6c8338edf3333fbe4da35dc72092643958ebb43f0ab2c49c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1f330b1edbef4041defea6c10bbb196add3c94c7e1b77778b6603e60ff0729"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,10 @@ tar = "0.4.40"
 zip = "0.6.6"
 md5 = "0.7.0"
 
-# dependency of the alsa-sys crate: librust-alsa-sys-dev
-rodio = "0.17.3"
+# Supporting library for rodio's "alsa-sys" dependency: librust-alsa-sys-dev
+# TODO(TicClick): The fork is a workaround for Windows not respecting default audio device change.
+# It can be removed along with TicClick/cpal once https://github.com/RustAudio/rodio/issues/463 is resolved.
+rodio = { git = "https://github.com/TicClick/rodio.git", branch = "master" } # v0.17.3
 png = "0.17.10"
 
 libloading = "0.8.1"


### PR DESCRIPTION
closes #57, while being a temporary fix

when this is rolled back, I need to remove the forks below:
- https://github.com/TicClick/rodio
- https://github.com/TicClick/cpal