### PR TITLE
Use unbounded queues for cross-thread communication to avoid overfilling when a window is minimized

### DIFF
--- a/crates/steel_core/src/ipc/client.rs
+++ b/crates/steel_core/src/ipc/client.rs
@@ -1,4 +1,4 @@
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::ipc::server::AppMessageIn;
 use crate::settings::application::AutoUpdate;
@@ -6,11 +6,11 @@ use crate::settings::Settings;
 
 #[derive(Debug)]
 pub struct CoreClient {
-    server: Sender<AppMessageIn>,
+    server: UnboundedSender<AppMessageIn>,
 }
 
 impl CoreClient {
-    pub fn new(server: Sender<AppMessageIn>) -> Self {
+    pub fn new(server: UnboundedSender<AppMessageIn>) -> Self {
         Self { server }
     }
 }
@@ -18,49 +18,47 @@ impl CoreClient {
 impl CoreClient {
     pub fn channel_opened(&self, channel: &str) {
         self.server
-            .blocking_send(AppMessageIn::UIChannelOpened(channel.to_owned()))
+            .send(AppMessageIn::UIChannelOpened(channel.to_owned()))
             .unwrap();
     }
 
     pub fn private_chat_opened(&self, chat: &str) {
         self.server
-            .blocking_send(AppMessageIn::UIPrivateChatOpened(chat.to_owned()))
+            .send(AppMessageIn::UIPrivateChatOpened(chat.to_owned()))
             .unwrap();
     }
 
     pub fn channel_join_requested(&self, channel: &str) {
         self.server
-            .blocking_send(AppMessageIn::UIChannelJoinRequested(channel.to_owned()))
+            .send(AppMessageIn::UIChannelJoinRequested(channel.to_owned()))
             .unwrap();
     }
 
     pub fn settings_requested(&self) {
-        self.server
-            .blocking_send(AppMessageIn::UISettingsRequested)
-            .unwrap();
+        self.server.send(AppMessageIn::UISettingsRequested).unwrap();
     }
 
     pub fn settings_updated(&self, settings: &Settings) {
         self.server
-            .blocking_send(AppMessageIn::UISettingsUpdated(settings.clone()))
+            .send(AppMessageIn::UISettingsUpdated(settings.clone()))
             .unwrap();
     }
 
     pub fn chat_tab_closed(&self, normalized_name: &str) {
         self.server
-            .blocking_send(AppMessageIn::UIChatClosed(normalized_name.to_owned()))
+            .send(AppMessageIn::UIChatClosed(normalized_name.to_owned()))
             .unwrap();
     }
 
     pub fn chat_tab_cleared(&self, normalized_name: &str) {
         self.server
-            .blocking_send(AppMessageIn::UIChatCleared(normalized_name.to_owned()))
+            .send(AppMessageIn::UIChatCleared(normalized_name.to_owned()))
             .unwrap();
     }
 
     pub fn chat_message_sent(&self, target: &str, text: &str) {
         self.server
-            .blocking_send(AppMessageIn::UIChatMessageSent {
+            .send(AppMessageIn::UIChatMessageSent {
                 target: target.to_owned(),
                 text: text.to_owned(),
             })
@@ -69,7 +67,7 @@ impl CoreClient {
 
     pub fn chat_action_sent(&self, target: &str, text: &str) {
         self.server
-            .blocking_send(AppMessageIn::UIChatActionSent {
+            .send(AppMessageIn::UIChatActionSent {
                 target: target.to_owned(),
                 text: text.to_owned(),
             })
@@ -77,26 +75,22 @@ impl CoreClient {
     }
 
     pub fn connect_requested(&self) {
-        self.server
-            .blocking_send(AppMessageIn::UIConnectRequested)
-            .unwrap();
+        self.server.send(AppMessageIn::UIConnectRequested).unwrap();
     }
 
     pub fn disconnect_requested(&self) {
         self.server
-            .blocking_send(AppMessageIn::UIDisconnectRequested)
+            .send(AppMessageIn::UIDisconnectRequested)
             .unwrap();
     }
 
     pub fn exit_requested(&self) {
-        self.server
-            .blocking_send(AppMessageIn::UIExitRequested)
-            .unwrap();
+        self.server.send(AppMessageIn::UIExitRequested).unwrap();
     }
 
     pub fn chat_switch_requested(&self, target: &str, message_id: Option<usize>) {
         self.server
-            .blocking_send(AppMessageIn::UIChatSwitchRequested(
+            .send(AppMessageIn::UIChatSwitchRequested(
                 target.to_owned(),
                 message_id,
             ))
@@ -105,31 +99,31 @@ impl CoreClient {
 
     pub fn usage_window_requested(&self) {
         self.server
-            .blocking_send(AppMessageIn::UIUsageWindowRequested)
+            .send(AppMessageIn::UIUsageWindowRequested)
             .unwrap();
     }
 
     pub fn update_settings_changed(&self, s: &AutoUpdate) {
         self.server
-            .blocking_send(AppMessageIn::UpdateSettingsChanged(s.clone()))
+            .send(AppMessageIn::UpdateSettingsChanged(s.clone()))
             .unwrap();
     }
 
     pub fn check_application_updates(&self) {
         self.server
-            .blocking_send(AppMessageIn::CheckApplicationUpdates)
+            .send(AppMessageIn::CheckApplicationUpdates)
             .unwrap();
     }
 
     pub fn download_application_update(&self) {
         self.server
-            .blocking_send(AppMessageIn::DownloadApplicationUpdate)
+            .send(AppMessageIn::DownloadApplicationUpdate)
             .unwrap();
     }
 
     pub fn abort_application_update(&self) {
         self.server
-            .blocking_send(AppMessageIn::AbortApplicationUpdate)
+            .send(AppMessageIn::AbortApplicationUpdate)
             .unwrap();
     }
 }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,6 +1,6 @@
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 pub trait Actor<T, U> {
-    fn new(input: Receiver<T>, output: Sender<U>) -> Self;
+    fn new(input: UnboundedReceiver<T>, output: UnboundedSender<U>) -> Self;
     fn handle_message(&mut self, message: T);
     fn run(&mut self);
 }

--- a/src/gui/state/mod.rs
+++ b/src/gui/state/mod.rs
@@ -5,7 +5,7 @@ use steel_core::ipc::updater::UpdateState;
 use steel_core::ipc::{client::CoreClient, server::AppMessageIn};
 
 use eframe::egui;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::core::settings::Settings;
 
@@ -48,7 +48,7 @@ pub struct UIState {
 }
 
 impl UIState {
-    pub fn new(app_queue_handle: Sender<AppMessageIn>) -> Self {
+    pub fn new(app_queue_handle: UnboundedSender<AppMessageIn>) -> Self {
         Self {
             connection: ConnectionStatus::default(),
             settings: Settings::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use tokio::sync::mpsc::channel;
+use tokio::sync::mpsc::unbounded_channel;
 
 pub mod actor;
 pub mod app;
@@ -9,7 +9,6 @@ pub mod gui;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-const UI_EVENT_QUEUE_SIZE: usize = 1000;
 const LOG_FILE_PATH: &str = "./runtime.log";
 
 fn setup_logging() {
@@ -41,7 +40,7 @@ fn main() {
     }
     setup_logging();
 
-    let (ui_queue_handle, ui_queue) = channel(UI_EVENT_QUEUE_SIZE);
+    let (ui_queue_handle, ui_queue) = unbounded_channel();
     let mut app = app::Application::new(ui_queue_handle);
     app.initialize();
 


### PR DESCRIPTION
this should resolve #119 -- the IRC thread cannot process any more messages because it is stuck waiting for the queue to be read. in turn, it is _not_ being read, because the consumer waits for the UI queue to free up, which is not happening since the window is minimized, and egui apparently has stopped repainting it since v0.26.something

of course, proper design should probably be to untie UI state updates from drawing, but I feel this may be a large enough task, so there's that