### PR TITLE
Improve chat highlighting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ chrono = { workspace = true }
 irc = { workspace = true }
 irc-proto = { workspace = true }
 futures = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_yaml = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/steel_core/Cargo.toml
+++ b/crates/steel_core/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 ecolor = { workspace = true }
 chrono = { workspace = true }
 irc-proto = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_yaml = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/steel_core/src/chat/mod.rs
+++ b/crates/steel_core/src/chat/mod.rs
@@ -118,11 +118,11 @@ impl Message {
         let text = self.text.to_lowercase();
         let text = text.trim();
         let keywords = if let Some(u) = username {
-            let mut kw = keywords.clone();
+            let mut kw: BTreeSet<String> = keywords.into_iter().map(|s| s.to_lowercase()).collect();
             kw.insert(u.to_lowercase());
             kw
         } else {
-            keywords.clone()
+            keywords.into_iter().map(|s| s.to_lowercase()).collect()
         };
 
         for keyword in &keywords {

--- a/crates/steel_core/src/chat/mod.rs
+++ b/crates/steel_core/src/chat/mod.rs
@@ -140,7 +140,7 @@ impl Message {
                 let is_keyword_suffix_alphanumeric =
                     keyword.ends_with(|ch: char| ch.is_alphanumeric());
                 let is_right_end_alphanumeric = keyword_end_pos < text.len() && {
-                    let next_byte: char = text.as_bytes()[keyword_end_pos + 1] as char;
+                    let next_byte: char = text.as_bytes()[keyword_end_pos] as char;
                     next_byte.is_alphanumeric()
                 };
 

--- a/crates/steel_core/src/chat/mod.rs
+++ b/crates/steel_core/src/chat/mod.rs
@@ -127,35 +127,38 @@ impl Message {
 
         for keyword in &keywords {
             if let Some(keyword_start_pos) = text.find(keyword) {
-                let is_message_prefix_matched = keyword_start_pos == 0;
-                let is_keyword_prefix_alphanumeric =
-                    keyword.starts_with(|ch: char| ch.is_alphanumeric());
-                let is_left_end_alphanumeric = keyword_start_pos > 0 && {
-                    let previous_byte: char = text.as_bytes()[keyword_start_pos - 1] as char;
-                    previous_byte.is_alphanumeric()
-                };
-
-                let keyword_end_pos = keyword_start_pos + keyword.len();
-                let is_message_suffix_matched = keyword_end_pos == text.len();
-                let is_keyword_suffix_alphanumeric =
-                    keyword.ends_with(|ch: char| ch.is_alphanumeric());
-                let is_right_end_alphanumeric = keyword_end_pos < text.len() && {
-                    let next_byte: char = text.as_bytes()[keyword_end_pos] as char;
-                    next_byte.is_alphanumeric()
-                };
-
-                if (is_message_prefix_matched
-                    || !is_keyword_prefix_alphanumeric
-                    || !is_left_end_alphanumeric)
-                    && (is_message_suffix_matched
-                        || !is_keyword_suffix_alphanumeric
-                        || !is_right_end_alphanumeric)
-                {
+                if Self::highlight_found(text, keyword, keyword_start_pos) {
                     self.highlight = true;
                     break;
                 }
             }
         }
+    }
+
+    fn highlight_found(text: &str, keyword: &str, keyword_start_pos: usize) -> bool {
+        let is_message_prefix_matched = keyword_start_pos == 0;
+        let is_keyword_prefix_alphanumeric =
+            keyword.starts_with(|ch: char| ch.is_alphanumeric());
+        let is_left_end_alphanumeric = keyword_start_pos > 0 && {
+            let previous_byte: char = text.as_bytes()[keyword_start_pos - 1] as char;
+            previous_byte.is_alphanumeric()
+        };
+
+        let keyword_end_pos = keyword_start_pos + keyword.len();
+        let is_message_suffix_matched = keyword_end_pos == text.len();
+        let is_keyword_suffix_alphanumeric =
+            keyword.ends_with(|ch: char| ch.is_alphanumeric());
+        let is_right_end_alphanumeric = keyword_end_pos < text.len() && {
+            let next_byte: char = text.as_bytes()[keyword_end_pos] as char;
+            next_byte.is_alphanumeric()
+        };
+
+        (is_message_prefix_matched
+            || !is_keyword_prefix_alphanumeric
+            || !is_left_end_alphanumeric)
+            && (is_message_suffix_matched
+                || !is_keyword_suffix_alphanumeric
+                || !is_right_end_alphanumeric)
     }
 }
 

--- a/src/gui/state/mod.rs
+++ b/src/gui/state/mod.rs
@@ -188,7 +188,8 @@ impl UIState {
                 message.detect_highlights(self.highlights.keywords(), current_username);
 
                 let contains_highlight = message.highlight;
-                let requires_attention = contains_highlight || !normalized.is_channel();
+                let requires_attention =
+                    !is_system_message && (contains_highlight || !normalized.is_channel());
 
                 if contains_highlight {
                     self.highlights.add(&normalized, &message);


### PR DESCRIPTION
- closes #149 by disabling highlights for system messages
- closes #116 by using a different highlight matching algorithm

regarding the second point, the change is that now if a "keyword" contains non-alphanumerical symbols from either side, it will match from that side unconditionally. with other types of "keywords", the message will be considered as a collection of words:

| message | highlight | match? |
| :-- | :-- | :-- |
| not now | no | - |
| ballisticKs! | sticks | - |
| stop!hammertime | !hammer | - |
| stop!hammertime | !hammertime | + |
| never,gonna,give,you,up | you | + |
| mirror mirror on the wall | on the wall | + |
| osu!supporter | osu! | + |
