### PR TITLE
Fix on-hover link disappearance on light theme

### DIFF
--- a/src/gui/window.rs
+++ b/src/gui/window.rs
@@ -113,6 +113,9 @@ fn update_ui_settings(ctx: &egui::Context, settings: &Settings) {
         ThemeMode::Dark => Theme::Dark,
         ThemeMode::Light => Theme::Light,
     });
+    ctx.style_mut(|style| {
+        style.url_in_tooltip = true;
+    });
 }
 
 pub struct ApplicationWindow {


### PR DESCRIPTION
closes #137 -- the egui default is the dark theme, and the light one doesn't have this on