### PR TITLE
Make chat usernames copyable on selection

### DIFF
--- a/src/gui/chat.rs
+++ b/src/gui/chat.rs
@@ -9,6 +9,7 @@ use steel_core::TextStyle;
 use crate::core::chat::{Chat, ChatLike, Message, MessageChunk, MessageType};
 use crate::gui::state::UIState;
 use crate::gui::widgets::chat::unread_marker::UnreadMarker;
+use crate::gui::widgets::selectable_button::SelectableButton;
 use crate::gui::{DecoratedText, CENTRAL_PANEL_INNER_MARGIN_Y};
 
 use crate::gui::command;
@@ -496,8 +497,9 @@ impl ChatWindow {
         }
         .with_styles(styles, &state.settings);
 
+        let invisible_text = format!(" <{}>", msg.username);
         #[allow(unused_mut)] // glass
-        let mut resp = ui.button(username_text);
+        let mut resp = ui.add(SelectableButton::new(username_text, invisible_text));
 
         #[cfg(feature = "glass")]
         if let Some(tt) = state.glass.show_user_tooltip(chat_name, msg) {

--- a/src/gui/widgets/mod.rs
+++ b/src/gui/widgets/mod.rs
@@ -1,1 +1,2 @@
 pub mod chat;
+pub mod selectable_button;

--- a/src/gui/widgets/selectable_button.rs
+++ b/src/gui/widgets/selectable_button.rs
@@ -1,0 +1,55 @@
+use eframe::egui;
+
+pub struct SelectableButton {
+    text: egui::WidgetText,
+    selectable_text: String,
+}
+
+impl SelectableButton {
+    pub fn new(text: impl Into<egui::WidgetText>, selectable_text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            selectable_text: selectable_text.into(),
+        }
+    }
+}
+
+impl egui::Widget for SelectableButton {
+    fn ui(self, ui: &mut egui::Ui) -> egui::Response {
+        let resp = ui.add(
+            egui::Label::new(
+                egui::RichText::new(&self.selectable_text).color(egui::Color32::TRANSPARENT),
+            )
+            .selectable(true),
+        );
+
+        // Draw button appearance over the selectable label, then draw visible text on top.
+
+        let button_rect = resp.rect.shrink2(egui::Vec2::new(2., 0.));
+        let visuals = ui.style().interact(&resp);
+        ui.painter()
+            .rect_filled(button_rect, visuals.corner_radius, visuals.bg_fill);
+        if visuals.bg_stroke.width > 0.0 {
+            ui.painter().rect_stroke(
+                button_rect,
+                visuals.corner_radius,
+                visuals.bg_stroke,
+                egui::epaint::StrokeKind::Outside,
+            );
+        }
+
+        let text_galley = self.text.into_galley(
+            ui,
+            Some(egui::TextWrapMode::Extend),
+            f32::INFINITY,
+            egui::TextStyle::Button,
+        );
+        ui.painter().galley(
+            button_rect.center() - text_galley.size() / 2.0,
+            text_galley,
+            visuals.text_color(),
+        );
+
+        resp.on_hover_cursor(egui::CursorIcon::Default)
+    }
+}


### PR DESCRIPTION
closes #163 -- had to make do since egui doesn't provide buttons with selectable text out of the box, only labels.