### PR TITLE
Preserve initial executable path for proper restart

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -90,7 +90,7 @@ impl Application {
                 }
 
                 AppMessageIn::UIRestartRequested => {
-                    crate::core::os::restart();
+                    crate::core::os::restart(None);
                 }
 
                 AppMessageIn::UIExitRequested => {

--- a/src/core/os.rs
+++ b/src/core/os.rs
@@ -82,10 +82,10 @@ pub fn cleanup_after_update() {
     }
 }
 
-pub fn restart() {
-    if let Ok(image) = std::env::current_exe() {
+pub fn restart(executable_path: Option<PathBuf>) {
+    if let Some(exe_path) = executable_path.or(std::env::current_exe().ok()) {
         log::debug!("restart: going to launch another copy of myself and then exit");
-        if let Err(e) = std::process::Command::new(&image).arg(&image).spawn() {
+        if let Err(e) = std::process::Command::new(&exe_path).arg(&exe_path).spawn() {
             log::error!("failed to restart myself: {:?}", e);
         } else {
             std::process::exit(0);

--- a/src/gui/state/mod.rs
+++ b/src/gui/state/mod.rs
@@ -39,6 +39,7 @@ pub struct UIState {
 
     pub update_state: UpdateState,
     pub sound_player: crate::core::sound::SoundPlayer,
+    pub original_exe_path: Option<std::path::PathBuf>,
 
     #[cfg(feature = "glass")]
     pub glass: glass::Glass,
@@ -49,7 +50,11 @@ pub struct UIState {
 }
 
 impl UIState {
-    pub fn new(app_queue_handle: UnboundedSender<AppMessageIn>, settings: Settings) -> Self {
+    pub fn new(
+        app_queue_handle: UnboundedSender<AppMessageIn>,
+        settings: Settings,
+        original_exe_path: Option<std::path::PathBuf>,
+    ) -> Self {
         let irc_settings = settings.chat.irc.clone();
         Self {
             connection: ConnectionStatus::default(),
@@ -61,6 +66,7 @@ impl UIState {
             read_tracker: read_tracker::ReadTracker::new(),
             update_state: UpdateState::default(),
             sound_player: crate::core::sound::SoundPlayer::new(),
+            original_exe_path,
 
             #[cfg(feature = "glass")]
             glass: {

--- a/src/gui/update_window.rs
+++ b/src/gui/update_window.rs
@@ -95,7 +95,7 @@ impl UpdateWindow {
                             m.tag_name
                         ));
                         if ui.button("restart now").clicked() {
-                            crate::core::os::restart();
+                            crate::core::os::restart(state.original_exe_path.clone());
                         }
                     }
                 }

--- a/src/gui/window.rs
+++ b/src/gui/window.rs
@@ -142,8 +142,13 @@ impl ApplicationWindow {
         ui_queue: UnboundedReceiver<UIMessageIn>,
         app_queue_handle: UnboundedSender<AppMessageIn>,
         initial_settings: Settings,
+        original_exe_path: Option<std::path::PathBuf>,
     ) -> Self {
-        let state = UIState::new(app_queue_handle, initial_settings.clone());
+        let state = UIState::new(
+            app_queue_handle,
+            initial_settings.clone(),
+            original_exe_path,
+        );
         set_startup_ui_settings(&cc.egui_ctx, &initial_settings);
 
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub fn setup_logging() {
 pub fn run_app(
     ui_queue_in: UnboundedSender<UIMessageIn>,
     ui_queue_out: UnboundedReceiver<UIMessageIn>,
+    original_exe_path: Option<std::path::PathBuf>,
 ) -> std::thread::JoinHandle<()> {
     let mut app = app::Application::new(ui_queue_in);
     app.initialize();
@@ -63,6 +64,7 @@ pub fn run_app(
                 ui_queue_out,
                 app_queue,
                 settings,
+                original_exe_path,
             )))
         }),
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,13 +6,16 @@ use steel::setup_logging;
 use tokio::sync::mpsc::unbounded_channel;
 
 fn main() {
+    // Save original executable path before any potential fs::rename operations -- it's not guaranteed to be preserved.
+    let original_exe_path = std::env::current_exe().ok();
+
     if let Err(e) = crate::core::os::fix_cwd() {
         panic!("Failed to set proper current working directory: {:?}", e);
     }
     setup_logging();
 
     let (ui_queue_in, ui_queue_out) = unbounded_channel();
-    let app_thread = run_app(ui_queue_in, ui_queue_out);
+    let app_thread = run_app(ui_queue_in, ui_queue_out, original_exe_path);
 
     app_thread.join().unwrap();
 }

--- a/visual-tests/src/main.rs
+++ b/visual-tests/src/main.rs
@@ -65,6 +65,10 @@ pub fn main() {
         std::thread::sleep(std::time::Duration::from_secs(1));
     });
 
-    let app_thread = run_app(ui_queue_in, ui_queue_out);
+    let app_thread = run_app(
+        ui_queue_in,
+        ui_queue_out,
+        std::env::current_exe().ok()
+    );
     app_thread.join().unwrap();
 }


### PR DESCRIPTION
closes #122 -- turns out the `std::env::current_exe()` is not guaranteed to return a different or even the same value after the file was renamed