### PR TITLE
Ping the server more frequently, so that ping_timeout actually has effect

### DIFF
--- a/src/core/irc/mod.rs
+++ b/src/core/irc/mod.rs
@@ -53,6 +53,7 @@ impl IRCActorHandle {
             realname: Some(username.to_owned()),
             use_tls: Some(false),
             ping_timeout: Some(ping_timeout),
+            ping_time: Some(10),
             ..Default::default()
         };
 


### PR DESCRIPTION
closes #214 -- it turns out that the default ping frequency is once in 3 minutes, which practically nullifies the ping timeout setting