### PR TITLE
Switch to the wgpu renderer in egui by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "alsa"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +318,15 @@ name = "as-raw-xcb-connection"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -946,6 +961,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
+ "serde",
+ "termcolor",
  "unicode-width",
 ]
 
@@ -1396,6 +1413,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
+ "pollster",
  "profiling",
  "raw-window-handle 0.6.2",
  "static_assertions",
@@ -1403,6 +1421,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "web-time 1.1.0",
+ "wgpu",
  "windows-sys 0.61.2",
  "winit 0.30.13",
 ]
@@ -2194,6 +2213,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.18",
+ "windows 0.62.2",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.11.0",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,6 +2298,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -2728,6 +2783,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
+]
+
+[[package]]
 name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3033,6 +3099,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "rustc-hash 1.1.0",
+ "spirv",
  "thiserror 2.0.18",
  "unicode-ident",
 ]
@@ -3414,7 +3481,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -3538,6 +3605,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3547,7 +3626,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -3558,7 +3637,9 @@ checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.11.0",
  "objc2 0.6.4",
+ "objc2-core-foundation",
  "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -3739,6 +3820,15 @@ checksum = "52ad2c6bae700b7aa5d1cc30c59bdd3a1c180b09dbaea51e2ae2b8e1cf211fdd"
 dependencies = [
  "libc",
  "libredox",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4051,6 +4141,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4226,6 +4322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
 name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4236,6 +4338,18 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
 
 [[package]]
 name = "read-fonts"
@@ -4901,6 +5015,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -6105,6 +6228,8 @@ dependencies = [
  "hashbrown 0.16.1",
  "js-sys",
  "log",
+ "naga",
+ "parking_lot",
  "portable-atomic",
  "profiling",
  "raw-window-handle 0.6.2",
@@ -6143,10 +6268,40 @@ dependencies = [
  "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.18",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
  "wgpu-naga-bridge",
  "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43acd053312501689cd92a01a9638d37f3e41a5fd9534875efa8917ee2d11ac0"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef043bf135cc68b6f667c55ff4e345ce2b5924d75bad36a47921b0287ca4b24a"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2f2fb042f36920771deb0b966543c5751b18f3d327760ffc90f74e20b2dcd4"
+dependencies = [
+ "wgpu-hal",
 ]
 
 [[package]]
@@ -6164,19 +6319,52 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
 dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
  "bitflags 2.11.0",
+ "block2 0.6.2",
+ "bytemuck",
  "cfg-if",
  "cfg_aliases 0.2.1",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
  "libloading",
  "log",
  "naga",
+ "ndk-sys 0.6.0+11769913",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
+ "profiling",
+ "range-alloc",
  "raw-window-handle 0.6.2",
+ "raw-window-metal",
  "renderdoc-sys",
+ "smallvec",
  "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
  "wgpu-naga-bridge",
  "wgpu-types",
+ "windows 0.62.2",
+ "windows-core",
+ "windows-result",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.dependencies]
-eframe = { version = "0.34", default-features = false, features = ["glow", "accesskit", "default_fonts", "wayland", "x11"] }
+eframe = { version = "0.34", default-features = false, features = ["glow", "wgpu", "accesskit", "default_fonts", "wayland", "x11"] }
 egui_extras = "0.34"
 ecolor = "0.34"
 egui_dnd = "0.15.0"

--- a/crates/steel_core/src/settings/application.rs
+++ b/crates/steel_core/src/settings/application.rs
@@ -10,6 +10,31 @@ pub struct Application {
     pub window: WindowGeometry,
     #[serde(default)]
     pub detached_chat_windows: BTreeMap<String, DetachedWindowGeometry>,
+    #[serde(default)]
+    pub renderer: Renderer,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Renderer {
+    #[default]
+    Auto,
+    Wgpu,
+    Glow,
+}
+
+impl std::fmt::Display for Renderer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Renderer::Auto => "auto",
+                Renderer::Wgpu => "wgpu (Direct3D 12 / Metal / Vulkan)",
+                Renderer::Glow => "glow (OpenGL)",
+            }
+        )
+    }
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/crates/steel_core/src/settings/mod.rs
+++ b/crates/steel_core/src/settings/mod.rs
@@ -11,7 +11,7 @@ use std::io::Write;
 use serde::{Deserialize, Serialize};
 use serde_yaml;
 
-pub use application::Application;
+pub use application::{Application, Renderer};
 pub use chat::{Chat, ChatBackend, HTTPChatSettings, IRCChatSettings, OAuthMode};
 pub use colour::Colour;
 pub use errors::SettingsError;

--- a/src/gui/settings/application.rs
+++ b/src/gui/settings/application.rs
@@ -1,4 +1,5 @@
 use eframe::egui;
+use steel_core::settings::Renderer;
 
 use super::SettingsWindow;
 use crate::{core::updater, gui::state::UIState};
@@ -75,6 +76,27 @@ impl SettingsWindow {
                     }
                 }
             }
+
+            ui.heading("graphics");
+            ui.horizontal(|ui| {
+                ui.label("renderer:");
+                egui::ComboBox::from_id_salt("application-renderer")
+                    .selected_text(state.settings.application.renderer.to_string())
+                    .show_ui(ui, |ui| {
+                        for option in [Renderer::Auto, Renderer::Wgpu, Renderer::Glow] {
+                            ui.selectable_value(
+                                &mut state.settings.application.renderer,
+                                option,
+                                option.to_string(),
+                            );
+                        }
+                    });
+            })
+            .response
+            .on_hover_text_at_pointer(
+                "graphics backend used to draw the interface (applied after a restart).\n\
+                \"auto\" prefers wgpu, but falls back to glow if the device doesn't support it",
+            );
         });
 
         if autoupdate != state.settings.application.autoupdate.enabled {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ pub fn setup_logging() {
             .add_filter_ignore_str("rustls")
             .add_filter_ignore_str("eframe")
             .add_filter_ignore_str("egui_glow")
+            .add_filter_ignore_str("egui_wgpu")
+            .add_filter_ignore_str("wgpu") // also covers wgpu_core and wgpu_hal
+            .add_filter_ignore_str("naga")
             .add_filter_ignore_str("ureq")
             .set_time_format_custom(time_format)
             .set_time_offset_to_local()
@@ -35,6 +38,56 @@ pub fn setup_logging() {
     )
     .expect("Failed to configure the logger");
     log_panics::init();
+}
+
+fn select_renderer(setting: steel_core::settings::Renderer) -> eframe::Renderer {
+    use steel_core::settings::Renderer as RendererSetting;
+
+    match setting {
+        RendererSetting::Glow => {
+            log::info!("renderer: glow (forced by settings)");
+            eframe::Renderer::Glow
+        }
+        RendererSetting::Auto | RendererSetting::Wgpu => match probe_wgpu_adapter() {
+            Some(adapter) => {
+                log::info!("renderer: wgpu ({adapter})");
+                eframe::Renderer::Wgpu
+            }
+            None => {
+                log::warn!("renderer: no usable wgpu adapter found, falling back to glow");
+                eframe::Renderer::Glow
+            }
+        },
+    }
+}
+
+// Probe the available adapter using logic from egui_wgpu::WgpuSetupCreateNew
+fn probe_wgpu_adapter() -> Option<String> {
+    use eframe::wgpu;
+
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::from_env()
+            .unwrap_or(wgpu::Backends::PRIMARY | wgpu::Backends::GL),
+        flags: wgpu::InstanceFlags::from_build_config().with_env(),
+        backend_options: wgpu::BackendOptions::from_env_or_default(),
+        memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+        display: None,
+    });
+    let request = instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::from_env()
+            .unwrap_or(wgpu::PowerPreference::HighPerformance),
+        ..Default::default()
+    });
+    match futures::executor::block_on(request) {
+        Ok(adapter) => {
+            let info = adapter.get_info();
+            Some(format!("{}, {:?} backend", info.name, info.backend))
+        }
+        Err(e) => {
+            log::warn!("wgpu adapter probe failed: {e}");
+            None
+        }
+    }
 }
 
 pub fn run_app(
@@ -65,6 +118,7 @@ pub fn run_app(
             eframe::icon_data::from_png_bytes(&include_bytes!("../media/icons/logo.png")[..])
                 .unwrap(),
         )),
+        renderer: select_renderer(settings.application.renderer),
         ..Default::default()
     };
     eframe::run_native(


### PR DESCRIPTION
https://wgpu.rs/index.html

rationale:
- potentially better performance
- egui will drift away from it https://github.com/emilk/egui/issues/5889 

glow, the previous renderer, is available as a fallback option